### PR TITLE
Set height on logo's

### DIFF
--- a/opoly/src/App.css
+++ b/opoly/src/App.css
@@ -21,8 +21,8 @@
 }
 
 .pawn-logo {
-  width: 70px;
-  height: auto;
+  height: 70px;
+  width: auto;
 }
 
 .pawn:hover {


### PR DESCRIPTION
## Set height on logo's

#### Summary
React logo isn't square, so it showed smaller than the other three.

#### Screenshot
![image](https://user-images.githubusercontent.com/31767869/44304143-fb634480-a353-11e8-95e2-5b9b4e375262.png)
